### PR TITLE
Changes from background agent bc-f65fc062-b8e4-459e-875f-84d00098d4ca

### DIFF
--- a/hrms-frontend/src/pages/HrAssistant/Evaluations/EvaluationTemplates.js
+++ b/hrms-frontend/src/pages/HrAssistant/Evaluations/EvaluationTemplates.js
@@ -4,7 +4,7 @@ import {
   Badge, Alert, Spinner, Modal
 } from 'react-bootstrap';
 import {
-  Template, Search, Copy, Eye, Trash2, Plus
+  FileTemplate, Search, Copy, Eye, Trash2, Plus
 } from 'lucide-react';
 import axios from 'axios';
 
@@ -107,7 +107,7 @@ const EvaluationTemplates = () => {
       ) : filteredTemplates.length === 0 ? (
         <Card className="text-center py-5">
           <Card.Body>
-            <Template size={64} className="text-muted mb-3" />
+            <FileTemplate size={64} className="text-muted mb-3" />
             <h5 className="text-muted">No Templates Found</h5>
             <p className="text-muted">
               {searchTerm ? 'No templates match your search criteria.' : 'No templates have been created yet.'}
@@ -122,7 +122,7 @@ const EvaluationTemplates = () => {
                 <Card.Header className="bg-light border-0">
                   <div className="d-flex justify-content-between align-items-start">
                     <Badge bg="primary" className="mb-2">
-                      <Template size={12} className="me-1" />
+                      <FileTemplate size={12} className="me-1" />
                       Template
                     </Badge>
                     <Badge bg="secondary">{template.questions?.length || 0} Questions</Badge>


### PR DESCRIPTION
Replace non-existent `Template` icon with `FileTemplate` from `lucide-react` to fix compilation error.

---
<a href="https://cursor.com/background-agent?bcId=bc-f65fc062-b8e4-459e-875f-84d00098d4ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f65fc062-b8e4-459e-875f-84d00098d4ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

